### PR TITLE
Add open & close window animations (v1.5–1.7)

### DIFF
--- a/Globals.hpp
+++ b/Globals.hpp
@@ -48,6 +48,8 @@ using Render::GL::CHyprOpenGLImpl;
 #include <hyprland/src/managers/fullscreen/FullscreenController.hpp>
 #include <hyprland/src/output/Monitor.hpp>
 #include <hyprland/src/pointer/PointerManager.hpp>
+#include <hyprland/src/managers/eventLoop/EventLoopManager.hpp>
+#include <hyprland/src/helpers/time/Time.hpp>
 
 // --- SHARED GLOBALS ---
 extern HANDLE PHANDLE;
@@ -70,8 +72,23 @@ struct WindowShaderState {
     std::string tiled;
     std::string fullscreen;
     std::string fallback;
+    std::string openAnim;          // one-shot reveal animation applied on window open
+    float       openAnimDuration = 1.0f; // seconds, via +shader_open_anim:/path@<sec>
 };
 extern std::unordered_map<Desktop::View::CWindow*, WindowShaderState> g_mWindowRuleShaders;
+
+// One-shot open animation state. progress starts at 0 (fully revealed hidden)
+// and ramps to 1.0 over `duration`; the entry is dropped once it completes.
+// For close animations (isClose) the entry is kept until the window is gone and
+// the shader freezes at progress==1.0 (window invisible) while close is pending.
+struct OpenAnimState {
+    std::string                            path;
+    std::chrono::steady_clock::time_point  start;
+    float                                  duration = 1.0f;
+    bool                                   isClose  = false;
+    bool                                   closeSent = false;
+};
+extern std::unordered_map<Desktop::View::CWindow*, OpenAnimState> g_mWindowOpenAnims;
 
 struct CompiledShader {
     Hyprutils::Memory::CSharedPointer<CShader> shader;
@@ -83,6 +100,8 @@ struct CompiledShader {
     GLint     isActiveLoc     = -1; // float 0/1
     GLint     isFloatingLoc   = -1; // float 0/1
     GLint     isFullscreenLoc = -1; // float 0/1
+    GLint     progressLoc     = -1; // float 0..1: one-shot open animation progress
+    GLint     seedLoc         = -1; // float 0..1: stable per-window random seed
     bool      usesTime        = false;
     time_t    sourceMtime     = 0; // mtime at compile time; lets us auto-evict on edit
 };
@@ -108,6 +127,9 @@ extern CFunctionHook* g_pUseShaderHook;
 extern thread_local PHLWINDOWREF      g_pCurrentRenderWindow;
 extern thread_local PHLLSREF          g_pCurrentRenderLayer;
 extern thread_local const std::string* g_pCurrentShaderPath;
+// Progress of the active one-shot open animation for the surface being drawn,
+// or -1.0 when no animation applies. Set by hkGLDrawTex, consumed by hkUseShader.
+extern thread_local float              g_pCurrentAnimProgress;
 // Cached compiled-shader pointer for the current draw. Set by hkGLDrawTex (one
 // resolve+compile lookup per surface), consumed by hkUseShader so it can apply
 // the shader and push uniforms without doing a second find on g_mCompiledCShaders.
@@ -118,3 +140,6 @@ CompiledShader*                             getOrCompileShader(const std::string
 void                                        hkGLDrawTex(void* thisptr, Hyprutils::Memory::CWeakPointer<CTexPassElement> element, const CRegion& damage);
 Hyprutils::Memory::CWeakPointer<CShader>    hkUseShader(CHyprOpenGLImpl* thisptr, Hyprutils::Memory::CWeakPointer<CShader> prog);
 void                                        applyShaderRulesSafe(PHLWINDOW pWindow);
+// Returns the active open-animation state for a window (owned by
+// g_mWindowOpenAnims), or nullptr. Only valid between render frames.
+OpenAnimState*                              getActiveOpenAnim(Desktop::View::CWindow* rawWin);

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -6,6 +6,7 @@ thread_local PHLWINDOWREF        g_pCurrentRenderWindow;
 thread_local PHLLSREF            g_pCurrentRenderLayer;
 thread_local const std::string*  g_pCurrentShaderPath     = nullptr;
 thread_local CompiledShader*     g_pCurrentCompiledShader = nullptr;
+thread_local float               g_pCurrentAnimProgress   = -1.0f;
 
 // Plugin-relative reference time so the `time` uniform stays in float-precision
 // range. steady_clock::now() seconds-since-epoch is in the billions and loses
@@ -58,6 +59,41 @@ static const std::string* resolveShaderPath(const PHLWINDOW& pWindow, const PHLL
     return nullptr;
 }
 
+// --- OPEN ANIMATION STATE ---
+// One-shot reveal animations live in g_mWindowOpenAnims keyed by raw window
+// pointer. They're created by the window.open listener and dropped either when
+// progress reaches 1.0 (in hkGLDrawTex, after the draw uses them) or when the
+// window is destroyed.
+OpenAnimState* getActiveOpenAnim(Desktop::View::CWindow* rawWin) {
+    auto it = g_mWindowOpenAnims.find(rawWin);
+    return it == g_mWindowOpenAnims.end() ? nullptr : &it->second;
+}
+
+// One-shot revert check for close animations. After the close request was sent,
+// a well-behaved client destroys the surface (-> window.destroy cleans up the
+// entry). If it's still alive after the grace period, it likely showed a dialog
+// (e.g. "unsaved changes") — restore the window so it's visible/usable again.
+static void scheduleCloseRevert(const PHLWINDOW& pWindow) {
+    Desktop::View::CWindow* rawWin = pWindow.get();
+    PHLWINDOWREF            weak   = pWindow;
+
+    auto timer = Hyprutils::Memory::makeShared<CEventLoopTimer>(
+        std::chrono::milliseconds(600),
+        [rawWin, weak](SP<CEventLoopTimer> self, void* data) {
+            (void)self;
+            (void)data;
+            auto w = weak.lock();
+            if (!w) return;
+            auto it = g_mWindowOpenAnims.find(rawWin);
+            if (it == g_mWindowOpenAnims.end() || !it->second.isClose) return;
+            g_mWindowOpenAnims.erase(rawWin);
+            g_pHyprRenderer->damageWindow(w);
+        },
+        nullptr);
+
+    g_pEventLoopManager->addTimer(timer);
+}
+
 // --- V0.56 HOOK: CGLElementRenderer::draw(CTexPassElement, CRegion) ---
 typedef void (*TGLDrawTex)(void* thisptr, Hyprutils::Memory::CWeakPointer<CTexPassElement> element, const CRegion& damage);
 
@@ -100,13 +136,42 @@ void hkGLDrawTex(void* thisptr, Hyprutils::Memory::CWeakPointer<CTexPassElement>
     // on g_mCompiledCShaders and stash the resulting pointer for hkUseShader
     // to consume — saves the second find that used to happen down there.
     const std::string* pathToUse = resolveShaderPath(pWindow, pLS);
+
+    // A one-shot open animation overrides whatever the normal resolution picked,
+    // and its progress (0..1) is fed to hkUseShader via the thread-local.
+    g_pCurrentAnimProgress = -1.0f;
+    if (pWindow) {
+        if (OpenAnimState* anim = getActiveOpenAnim(pWindow.get())) {
+            pathToUse = &anim->path;
+            const float elapsed = std::chrono::duration_cast<std::chrono::duration<float>>(
+                                      std::chrono::steady_clock::now() - anim->start)
+                                      .count();
+            g_pCurrentAnimProgress = anim->duration > 0.0f ? std::min(elapsed / anim->duration, 1.0f) : 1.0f;
+        }
+    }
+
     g_pCurrentShaderPath         = pathToUse;
     g_pCurrentCompiledShader     = pathToUse && !pathToUse->empty()
                                        ? getOrCompileShader(*pathToUse)
                                        : nullptr;
 
-    // Schedule continuous redraw if the resolved shader uses `time`.
-    if (g_pCurrentCompiledShader && g_pCurrentCompiledShader->usesTime) {
+    // Schedule continuous redraw if the resolved shader uses `time`, or while
+    // a one-shot animation is still running (its shader may not bind `time`).
+    const bool animActive = g_pCurrentAnimProgress >= 0.0f;
+    bool       needsDamage = false;
+    if (g_pCurrentCompiledShader && g_pCurrentCompiledShader->usesTime)
+        needsDamage = true;
+    else if (animActive && pWindow)
+        needsDamage = true;
+
+    // A close animation freezes at progress==1.0 with the window invisible once
+    // the close request was sent — stop re-damaging it; it either gets destroyed
+    // or is reverted by the timer below.
+    if (needsDamage && pWindow) {
+        if (OpenAnimState* a = getActiveOpenAnim(pWindow.get()); a && a->isClose && a->closeSent)
+            needsDamage = false;
+    }
+    if (needsDamage) {
         if (pWindow)
             g_pHyprRenderer->damageWindow(pWindow);
         else if (pLS) {
@@ -117,10 +182,30 @@ void hkGLDrawTex(void* thisptr, Hyprutils::Memory::CWeakPointer<CTexPassElement>
 
     ((TGLDrawTex)g_pGLDrawTexHook->m_original)(thisptr, element, damage);
 
+    // Animation completion.
+    // Open animations: drop the entry and damage once more so the frame after
+    // completion renders with the normal (non-anim) shader — the final animated
+    // frame at progress==1.0 already shows the fully-revealed window.
+    // Close animations: send the close request and KEEP the entry so the window
+    // stays invisible (shader frozen at progress==1.0) until it's destroyed or
+    // a revert timer restores it (client showed a dialog instead of closing).
+    if (animActive && g_pCurrentAnimProgress >= 1.0f && pWindow) {
+        OpenAnimState* anim = getActiveOpenAnim(pWindow.get());
+        if (anim && anim->isClose) {
+            if (!anim->closeSent) {
+                anim->closeSent = true;
+                pWindow->sendClose();
+                scheduleCloseRevert(pWindow);
+            }
+        } else if (g_mWindowOpenAnims.erase(pWindow.get()))
+            g_pHyprRenderer->damageWindow(pWindow);
+    }
+
     g_pCurrentRenderWindow.reset();
     g_pCurrentRenderLayer.reset();
     g_pCurrentShaderPath     = nullptr;
     g_pCurrentCompiledShader = nullptr;
+    g_pCurrentAnimProgress   = -1.0f;
 }
 
 // --- V0.56 HOOK: useShader ---
@@ -183,6 +268,23 @@ Hyprutils::Memory::CWeakPointer<CShader> hkUseShader(CHyprOpenGLImpl* thisptr, H
             const float v = (contextWindow && Fullscreen::controller()->isFullscreen(contextWindow)) ? 1.0f : 0.0f;
             glUniform1f(activeEntry->isFullscreenLoc, v);
         }
+        if (activeEntry->progressLoc >= 0) {
+            const float p = g_pCurrentAnimProgress >= 0.0f ? g_pCurrentAnimProgress : 1.0f;
+            glUniform1f(activeEntry->progressLoc, p);
+        }
+        if (activeEntry->seedLoc >= 0) {
+            // Stable per-window random seed (0..1) so each open animation has its
+            // own pattern, like Niri's niri_random_seed. Derived from the window
+            // pointer; stable for the whole life of the window.
+            float s = 0.5f;
+            if (contextWindow) {
+                const uint64_t h = (uint64_t)(uintptr_t)contextWindow.get() * 2654435761u;
+                s = (float)(h >> 32) / 4294967295.0f;
+            } else if (auto l = g_pCurrentRenderLayer.lock()) {
+                s = (float)(std::hash<std::string>{}(l->m_namespace) % 100000) / 100000.0f;
+            }
+            glUniform1f(activeEntry->seedLoc, s);
+        }
     }
 
     return result;
@@ -217,6 +319,21 @@ void applyShaderRulesSafe(PHLWINDOW pWindow) {
         else if (sv.substr(0, 16) == "shader_floating:")   assign(state.floating,   16);
         else if (sv.substr(0, 13) == "shader_tiled:")      assign(state.tiled,      13);
         else if (sv.substr(0, 18) == "shader_fullscreen:") assign(state.fullscreen, 18);
+        else if (sv.substr(0, 17) == "shader_open_anim:") {
+            // Optional @<seconds> suffix sets the animation duration.
+            const std::string_view rest = sv.substr(17);
+            const size_t          at   = rest.find('@');
+            if (at != std::string_view::npos) {
+                state.openAnim.assign(rest.substr(0, at));
+                try {
+                    const float d = std::stof(std::string(rest.substr(at + 1)));
+                    if (d > 0.0f) state.openAnimDuration = d;
+                } catch (...) {}
+            } else {
+                state.openAnim.assign(rest);
+            }
+            hasRules = true;
+        }
     }
 
     if (hasRules) {

--- a/ShaderEngine.cpp
+++ b/ShaderEngine.cpp
@@ -126,6 +126,8 @@ CompiledShader* getOrCompileShader(const std::string& shaderPath) {
     entry.isActiveLoc     = glGetUniformLocation(prog, "is_active");
     entry.isFloatingLoc   = glGetUniformLocation(prog, "is_floating");
     entry.isFullscreenLoc = glGetUniformLocation(prog, "is_fullscreen");
+    entry.progressLoc     = glGetUniformLocation(prog, "progress");
+    entry.seedLoc         = glGetUniformLocation(prog, "seed");
     // Continuous redraw is needed only when the shader actually binds `time`.
     // Using the location instead of substring matching avoids false positives
     // like "lifetime" or "uniform_time_offset".

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,12 @@ if [ "$HDR_COMMIT" != "$RUN_COMMIT" ]; then
 fi
 
 echo "[Plugin] Unloading previous version from memory..."
-hyprctl plugin unload "$PLUGIN_PATH"
+hyprctl plugin unload "$PLUGIN_PATH" >/dev/null 2>&1
+# Older dev builds were loaded from unique /tmp copies; unload those too so the
+# reload below doesn't end up with two HyprWindowShade instances.
+for stale in /tmp/HyprWindowShade-*.so; do
+    [ -e "$stale" ] && hyprctl plugin unload "$stale" >/dev/null 2>&1
+done
 sleep 2
 
 echo "[Build] Running make..."
@@ -68,6 +73,17 @@ mv "$(pwd)/HyprWindowShade.so" "$PLUGIN_PATH"
 echo -e "${GREEN}Complete!${NC}"
 
 echo "[Plugin] Loading new version..."
-hyprctl plugin load "$PLUGIN_PATH"
+# v0.56: `hyprctl plugin load` on the same path right after an unload can reuse a
+# stale, still-mapped module (deferred dlclose) and silently keep the previous
+# build alive. Load a fresh copy under a unique path so PLUGIN_INIT runs for real.
+TMP_PLUGIN="/tmp/HyprWindowShade-$$.so"
+cp "$PLUGIN_PATH" "$TMP_PLUGIN"
+LOAD_OUT=$(hyprctl plugin load "$TMP_PLUGIN" 2>&1)
+if echo "$LOAD_OUT" | grep -qiE "could not be loaded|error"; then
+    echo -e "${RED}[Error] Plugin load failed:${NC}"
+    echo "$LOAD_OUT"
+    exit 1
+fi
+echo "$LOAD_OUT"
 
 echo -e "${GREEN}[Success] HyprWindowShade is now live!${NC}"

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@ HANDLE                                                PHANDLE = nullptr;
 std::vector<CHyprSignalListener>                      g_Listeners;
 std::unordered_map<Desktop::View::CWindow*, std::string>        g_mWindowManualShaders;
 std::unordered_map<Desktop::View::CWindow*, WindowShaderState>  g_mWindowRuleShaders;
+std::unordered_map<Desktop::View::CWindow*, OpenAnimState>      g_mWindowOpenAnims;
 std::map<std::string, std::string>                    g_mLayerNamespaceShaderMap;
 std::map<std::string, std::string>                    g_mWindowClassShaderMap;
 std::map<std::string, CompiledShader>                 g_mCompiledCShaders;
@@ -116,6 +117,36 @@ namespace shadeActions {
         for (auto& m : State::monitorState()->monitors()) if (m) m->scheduleFrame();
         HyprlandAPI::addNotification(PHANDLE, "[HyprWindowShade] Shaders Reloaded from Disk!", CHyprColor(0.2f, 1.0f, 0.2f, 1.0f), 3000.0f);
     }
+
+    // Play a one-shot close animation on the focused window (path[@seconds],
+    // default duration 1.2s). At progress==1.0 the hook sends the close request
+    // and keeps the window invisible until it's destroyed (or reverted by timer).
+    static void closeAnim(const std::string& arg) {
+        if (arg.empty()) return;
+
+        std::string path    = arg;
+        float       duration = 0.5f;
+        const size_t at = path.find('@');
+        if (at != std::string::npos) {
+            try {
+                const float d = std::stof(path.substr(at + 1));
+                if (d > 0.0f) duration = d;
+            } catch (...) {}
+            path = path.substr(0, at);
+        }
+
+        PHLWINDOW pWindow = g_lastActiveWindow.lock();
+        if (!pWindow) return;
+
+        OpenAnimState anim;
+        anim.path      = path;
+        anim.start     = std::chrono::steady_clock::now();
+        anim.duration  = duration;
+        anim.isClose   = true;
+        anim.closeSent = false;
+        g_mWindowOpenAnims[pWindow.get()] = std::move(anim);
+        g_pHyprRenderer->damageWindow(pWindow);
+    }
 }
 
 // --- LUA C WRAPPERS ---
@@ -146,6 +177,10 @@ static int luaToggleClassShader(lua_State* L) {
 static int luaReloadShaders(lua_State* L) {
     (void)L;
     shadeActions::reloadShaders();
+    return 0;
+}
+static int luaCloseAnim(lua_State* L) {
+    shadeActions::closeAnim(luaL_checkstring(L, 1));
     return 0;
 }
 
@@ -206,6 +241,23 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         if (window) g_pHyprRenderer->damageWindow(window);
     }));
 
+    // Kick off the one-shot open animation (smoke reveal) for windows that have
+    // a +shader_open_anim: rule. Niri-style: progress 0->1 over ~1.5s, then the
+    // shader is dropped automatically when progress hits 1.0.
+    g_Listeners.push_back(Event::bus()->m_events.window.open.listen([](PHLWINDOW window) {
+        if (!window) return;
+        Desktop::View::CWindow* rawWin = window.get();
+        auto it = g_mWindowRuleShaders.find(rawWin);
+        if (it == g_mWindowRuleShaders.end() || it->second.openAnim.empty()) return;
+
+        OpenAnimState anim;
+        anim.path     = it->second.openAnim;
+        anim.start    = std::chrono::steady_clock::now();
+        anim.duration = it->second.openAnimDuration;
+        g_mWindowOpenAnims[rawWin] = std::move(anim);
+        g_pHyprRenderer->damageWindow(window);
+    }));
+
     // Drop entries keyed by raw CWindow* when the window is destroyed so they
     // can't accidentally match a future window at the same address.
     // V0.56: window.destroy emits PHLWINDOWREF (the shared ref is already gone
@@ -216,6 +268,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         Desktop::View::CWindow* rawWin = window.get();
         g_mWindowManualShaders.erase(rawWin);
         g_mWindowRuleShaders.erase(rawWin);
+        g_mWindowOpenAnims.erase(rawWin);
     }));
 
     // --- DISPATCHERS (.conf-style — Hyprland's native bind path) ---
@@ -259,6 +312,12 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         return SDispatchResult{};
     });
 
+    HyprlandAPI::addDispatcherV2(PHANDLE, "closeanim", [](std::string args) -> SDispatchResult {
+        trimInPlace(args);
+        shadeActions::closeAnim(args);
+        return SDispatchResult{};
+    });
+
     // --- LUA FUNCTIONS (hl.plugin.HyprWindowShade.* — for Lua-based configs) ---
     // Removed automatically on plugin unload (per PluginAPI.hpp), but PLUGIN_EXIT
     // calls removeLuaFunction defensively to keep teardown symmetric.
@@ -268,8 +327,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addLuaFunction(PHANDLE, "HyprWindowShade", "classshader",        &luaClassShader);
     HyprlandAPI::addLuaFunction(PHANDLE, "HyprWindowShade", "toggleclassshader",  &luaToggleClassShader);
     HyprlandAPI::addLuaFunction(PHANDLE, "HyprWindowShade", "reloadshaders",      &luaReloadShaders);
+    HyprlandAPI::addLuaFunction(PHANDLE, "HyprWindowShade", "closeanim",          &luaCloseAnim);
 
-    return {"HyprWindowShade", "Native CShader Injection (v0.56)", "ManofJELLO", "1.4"};
+    return {"HyprWindowShade", "Native CShader Injection (v0.56)", "ManofJELLO", "1.7"};
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
@@ -277,6 +337,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
 
     g_mWindowManualShaders.clear();
     g_mWindowRuleShaders.clear();
+    g_mWindowOpenAnims.clear();
     g_mLayerNamespaceShaderMap.clear();
     g_mWindowClassShaderMap.clear();
     g_mFailedShaderMtimes.clear();
@@ -296,6 +357,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
     HyprlandAPI::removeDispatcher(PHANDLE, "classshader");
     HyprlandAPI::removeDispatcher(PHANDLE, "toggleclassshader");
     HyprlandAPI::removeDispatcher(PHANDLE, "reloadshaders");
+    HyprlandAPI::removeDispatcher(PHANDLE, "closeanim");
 
     HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "layershader");
     HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "togglelayershader");
@@ -303,4 +365,5 @@ APICALL EXPORT void PLUGIN_EXIT() {
     HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "classshader");
     HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "toggleclassshader");
     HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "reloadshaders");
+    HyprlandAPI::removeLuaFunction(PHANDLE, "HyprWindowShade", "closeanim");
 }


### PR DESCRIPTION
Open/close window animations via progress/seed uniforms, new closeanim dispatcher + Lua function, build.sh reload fix. Shader files live separately under ~/.config/hypr/shaders/.