### PR TITLE
feat: add shader_open_default and shader_close_default fallback tags …

### DIFF
--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -533,6 +533,10 @@ void applyShaderRulesSafe(PHLWINDOW pWindow) {
 
     WindowShaderState state;
     bool              hasRules = false;
+    std::string       defaultOpenAnim;
+    float             defaultOpenAnimDuration = -1.0f;
+    std::string       defaultCloseAnim;
+    float             defaultCloseAnimDuration = -1.0f;
 
     const auto& tagsSet = pWindow->m_ruleApplicator->m_tagKeeper.getTags();
     for (const auto& tag : tagsSet) {
@@ -579,8 +583,21 @@ void applyShaderRulesSafe(PHLWINDOW pWindow) {
         else if (sv.substr(0, 16) == "shader_floating:")   assign(state.floating,   16);
         else if (sv.substr(0, 13) == "shader_tiled:")      assign(state.tiled,      13);
         else if (sv.substr(0, 18) == "shader_fullscreen:") assign(state.fullscreen, 18);
+        else if (sv.substr(0, 20) == "shader_open_default:")  assignAnim(defaultOpenAnim,  defaultOpenAnimDuration,  20);
+        else if (sv.substr(0, 21) == "shader_close_default:") assignAnim(defaultCloseAnim, defaultCloseAnimDuration, 21);
         else if (sv.substr(0, 12) == "shader_open:")       assignAnim(state.openAnim,  state.openAnimDuration,  12);
         else if (sv.substr(0, 13) == "shader_close:")      assignAnim(state.closeAnim, state.closeAnimDuration, 13);
+    }
+
+    if (state.openAnim.empty() && !defaultOpenAnim.empty()) {
+        state.openAnim = std::move(defaultOpenAnim);
+        state.openAnimDuration = defaultOpenAnimDuration;
+        hasRules = true;
+    }
+    if (state.closeAnim.empty() && !defaultCloseAnim.empty()) {
+        state.closeAnim = std::move(defaultCloseAnim);
+        state.closeAnimDuration = defaultCloseAnimDuration;
+        hasRules = true;
     }
 
     if (hasRules) {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ end
 
 ## Window shaders
 
-Apply a shader to a window with a `tag` on a window rule. Eight tags are supported:
+Apply a shader to a window with a `tag` on a window rule. Ten tags are supported:
 
 | Tag | Behavior |
 |---|---|
@@ -115,7 +115,9 @@ Apply a shader to a window with a `tag` on a window rule. Eight tags are support
 | `+shader_floating:/path.glsl` | Applies only when floating |
 | `+shader_tiled:/path.glsl` | Applies only when tiled |
 | `+shader_open:/path.glsl` | Plays once when the window opens, then reverts to the window's normal shader |
+| `+shader_open_default:/path.glsl` | Fallback open animation (yields to a specific `+shader_open:`) |
 | `+shader_close:/path.glsl` | Plays once as the window closes |
+| `+shader_close_default:/path.glsl` | Fallback close animation (yields to a specific `+shader_close:`) |
 
 The leading `+` means "apply this tag" — the same prefix Hyprland's tag system uses everywhere. If a window carries both a floating rule and an active rule, the floating shader wins while the window is floating.
 


### PR DESCRIPTION
### Summary

  This PR introduces `+shader_open_default`: and `+shader_close_default`: window rule tags to
  solve tag precedence when combining specific per-app animation rules with a global
  fallback rule.

  ### Problem

  Hyprland stores tags in an std::set<std::string>, which sorts elements alphabetically.
  When a user defines both a generic fallback rule (e.g. match:class .*, tag
  +shader_close:.../smoke_close.glsl) and a specific per-app rule (e.g. match:class
  ^(kitty)$, tag +shader_close:.../matrix_close.glsl), both tags attach to the window.

  During applyShaderRulesSafe(), tags are iterated in alphabetical order. If the default
  shader's path sorts after the specific one (e.g. smoke after matrix), the default shader
  overwrites the specific rule.

  ### Solution

  1. Added support for shader_open_default: and shader_close_default: tags.
  2. In applyShaderRulesSafe():
      • Specific tags (+shader_open:, +shader_close:) always take priority.
      • If no specific tag is attached to the window, the default fallback tag is used.
  3. Updated the tag reference table in README.md.

  ### Example Usage

    -- Specific animation for kitty
    hl.window_rule({
        match = { class = "^(kitty)$" },
        tag   = "+shader_close:/path/to/matrix_close.glsl@0.8",
    })

    -- Global fallback for all other windows
    hl.window_rule({
        match = { class = ".*" },
        tag   = "+shader_close_default:/path/to/smoke_close.glsl@1.0",
    })